### PR TITLE
Correct spelling of globalcache in module list

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -78,8 +78,8 @@
 							<li>Dataton Watchout</li>
 							<li>Digital Projection Highlight</li>
 							<li>Epson Projectors <span class="badge badge-success">New</span></li>
-							<li>Globalcache-itac-ir <span class="badge badge-success">New</span></li>
-							<li>Globalcache-itac-cc <span class="badge badge-success">New</span></li>
+							<li>Globalcache iTach IP2IR <span class="badge badge-success">New</span></li>
+							<li>Globalcache iTach IP2CC <span class="badge badge-success">New</span></li>
 							<li>GrandMA 2 (telnet) </li>
 							<li>GrassValley AMP protocol <span class="badge badge-success">New</span></li>
 							<li>High End Systems Hog 4 <span class="badge badge-success">New</span></li>
@@ -180,6 +180,7 @@
 					<ul>
 						<li><a href="https://www.facebook.com/dave.shepherd.5494">Dave Shepherd</a></li>
 						<li><a href="https://github.com/silid">Simon Liddicott</a></li>
+						<li><a href="https://github.com/monoxane">Oliver Herrmann</a></li>
 						<li><a href="https://github.com/cxselph">Casey Selph</a></li>
 						<li><a href="https://github.com/JeffreyDavidsz">Jeffrey Davidsz</a></li>
 						<li><a href="https://www.facebook.com/tyl3r.krupa?fref=gc&dti=2047850215433318">Tyler Krupa</a></li>

--- a/static/index.html
+++ b/static/index.html
@@ -78,8 +78,8 @@
 							<li>Dataton Watchout</li>
 							<li>Digital Projection Highlight</li>
 							<li>Epson Projectors <span class="badge badge-success">New</span></li>
-							<li>Globalcashe-itac-ir <span class="badge badge-success">New</span></li>
-							<li>Globalcashe-itac-cc <span class="badge badge-success">New</span></li>
+							<li>Globalcache-itac-ir <span class="badge badge-success">New</span></li>
+							<li>Globalcache-itac-cc <span class="badge badge-success">New</span></li>
 							<li>GrandMA 2 (telnet) </li>
 							<li>GrassValley AMP protocol <span class="badge badge-success">New</span></li>
 							<li>High End Systems Hog 4 <span class="badge badge-success">New</span></li>
@@ -90,12 +90,12 @@
 							<li>Irisdown Countdown Timer 2.0 <span class="badge badge-success">New</span></li>
 							<li>Kramer VP-727 <span class="badge badge-success">New</span></li>
 							<li>Lightware LW2 Devices <span class="badge badge-success">New</span></li>
-							<li>Lightware LW3 Devices <span class="badge badge-success">New</span></li> 
+							<li>Lightware LW3 Devices <span class="badge badge-success">New</span></li>
 							<li>Microsoft Powerpoint (via Octopus Listener and Irisdown Remote Show control) </li>
 							<li>Millumin</li>
 							<li>Mitti</li>
-							<li>Modulo Pi Modulo Player <span class="badge badge-success">New</span></li> 
-							<li>Motu AVB interfaces / Mixers <span class="badge badge-success">New</span></li> 
+							<li>Modulo Pi Modulo Player <span class="badge badge-success">New</span></li>
+							<li>Motu AVB interfaces / Mixers <span class="badge badge-success">New</span></li>
 							<li>OSC Generic (send custom packets)</li>
 							<li>Octopus Listener </li>
 							<li>Panasonic AW-HS50/AV-HS410 Switchers <span class="badge badge-success">New</span></li>
@@ -125,24 +125,24 @@
 							<li>Ember+</li>
 							<li>Entec DMXPro</li>
 							<li>Extron Matrix Routers</li>
-							<li>Extron Presentation Switchers</li>		
+							<li>Extron Presentation Switchers</li>
 							<li>GrassValley Switchers</li>
 							<li>Green Hippo</li>
 							<li>GreenGo Digital</li>
 							<li>Kramer Matrix Routers</li>
-							<li>Kramer Presentation Switchers</li>								
+							<li>Kramer Presentation Switchers</li>
 							<li>NEC Projectors</li>
 							<li>Nevion Routers</li>
 							<li>Newtek Tricaster</li>
-							<li>OBS</li>				
+							<li>OBS</li>
 							<li>Panasonic PTZ</li>
 							<li>Panasonic Projectors</li>
 							<li>Philips Hue</li>
 							<li>Roland XS series</li>
-							<li>Sony / VISCA PTZ</li>					
+							<li>Sony / VISCA PTZ</li>
 							<li>TJ Show (Windows)</li>
 							<li>TSL Protocol</li>
-							<li>UDP/TCP Generic module</li>					
+							<li>UDP/TCP Generic module</li>
 							<li>VirtualVTR PRO *(Mac)</li>
 							<li>Wirecast</li>
 							<li>Yamaha Ql series Consoles</li>


### PR DESCRIPTION
Looks like my editor cleaned up some extra spacing on its own. Let me know if that causes any issues.